### PR TITLE
streamline matches

### DIFF
--- a/app/src/main/java/com/uwcs446/socialsports/domain/match/Match.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/domain/match/Match.kt
@@ -7,7 +7,7 @@ import java.time.LocalTime
 
 data class Match(
     val id: String,
-    val type: MatchType,
+    val sport: Sport,
     val title: String,
     val description: String,
     val date: LocalDate,
@@ -17,9 +17,9 @@ data class Match(
     val teamOne: List<User>,
     val teamTwo: List<User>
 ) {
-    fun teamSize() = this.type.teamSize
+    fun teamSize() = this.sport.teamSize
 
-    fun maxPlayerCount() = this.type.teamSize * 2
+    fun maxPlayerCount() = this.sport.teamSize * 2
 
     fun currentPlayerCount() = teamOne.size.plus(teamTwo.size)
 }

--- a/app/src/main/java/com/uwcs446/socialsports/domain/match/Match.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/domain/match/Match.kt
@@ -2,24 +2,24 @@ package com.uwcs446.socialsports.domain.match
 
 import com.uwcs446.socialsports.domain.user.User
 import java.time.Duration
-import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
 
 data class Match(
     val id: String,
     val type: MatchType,
     val title: String,
     val description: String,
-    val time: Instant,
+    val date: LocalDate,
+    val time: LocalTime,
     val duration: Duration,
     val host: User,
-    val players: List<List<User>>,
+    val teamOne: List<User>,
+    val teamTwo: List<User>
 ) {
-    fun teamCount() = this.type.teamCount
-
     fun teamSize() = this.type.teamSize
 
-    fun playersByTeam(team: Int): List<User> {
-        return if (team > teamCount()) emptyList()
-        else players[team - 1]
-    }
+    fun maxPlayerCount() = this.type.teamSize * 2
+
+    fun currentPlayerCount() = teamOne.size.plus(teamTwo.size)
 }

--- a/app/src/main/java/com/uwcs446/socialsports/domain/match/MatchType.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/domain/match/MatchType.kt
@@ -1,8 +1,8 @@
 package com.uwcs446.socialsports.domain.match
 
-enum class MatchType(val teamCount: Int, val teamSize: Int) {
+enum class MatchType(val teamSize: Int) {
 
-    SOCCER(teamCount = 2, teamSize = 10),
-    BASKETBALL(teamCount = 2, teamSize = 10),
-    ULTIMATE(teamCount = 2, teamSize = 10)
+    SOCCER(teamSize = 10),
+    BASKETBALL(teamSize = 10),
+    ULTIMATE(teamSize = 10)
 }

--- a/app/src/main/java/com/uwcs446/socialsports/domain/match/Sport.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/domain/match/Sport.kt
@@ -1,6 +1,6 @@
 package com.uwcs446.socialsports.domain.match
 
-enum class MatchType(val teamSize: Int) {
+enum class Sport(val teamSize: Int) {
 
     SOCCER(teamSize = 10),
     BASKETBALL(teamSize = 10),

--- a/app/src/main/java/com/uwcs446/socialsports/services/match/MatchAssembler.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/services/match/MatchAssembler.kt
@@ -12,19 +12,23 @@ fun Match.toEntity() =
         type = type,
         description = description,
         host = host.toEntity(),
+        date = date,
         time = time,
         duration = duration.toMinutes(),
-        players = players.map { it.map { user -> user.toEntity() } }
+        teamOne = teamOne.map { it.toEntity() },
+        teamTwo = teamTwo.map { it.toEntity() }
     )
 
 fun MatchEntity.toDomain() =
     Match(
         id = id,
-        title = title,
         type = type,
+        title = title,
         description = description,
-        host = host.toDomain(),
+        date = date,
         time = time,
         duration = Duration.ofMinutes(duration),
-        players = players.map { it.map { user -> user.toDomain() } }
+        host = host.toDomain(),
+        teamOne = teamOne.map { it.toDomain() },
+        teamTwo = teamTwo.map { it.toDomain() }
     )

--- a/app/src/main/java/com/uwcs446/socialsports/services/match/MatchAssembler.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/services/match/MatchAssembler.kt
@@ -9,7 +9,7 @@ fun Match.toEntity() =
     MatchEntity(
         id = id,
         title = title,
-        type = type,
+        sport = sport,
         description = description,
         host = host.toEntity(),
         date = date,
@@ -22,7 +22,7 @@ fun Match.toEntity() =
 fun MatchEntity.toDomain() =
     Match(
         id = id,
-        type = type,
+        sport = sport,
         title = title,
         description = description,
         date = date,

--- a/app/src/main/java/com/uwcs446/socialsports/services/match/MatchEntity.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/services/match/MatchEntity.kt
@@ -1,6 +1,6 @@
 package com.uwcs446.socialsports.services.match
 
-import com.uwcs446.socialsports.domain.match.MatchType
+import com.uwcs446.socialsports.domain.match.Sport
 import com.uwcs446.socialsports.services.user.UserEntity
 import java.time.LocalDate
 import java.time.LocalTime
@@ -8,7 +8,7 @@ import java.time.LocalTime
 data class MatchEntity(
     val id: String,
     val title: String,
-    val type: MatchType,
+    val sport: Sport,
     val description: String,
     val host: UserEntity,
     val date: LocalDate,

--- a/app/src/main/java/com/uwcs446/socialsports/services/match/MatchEntity.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/services/match/MatchEntity.kt
@@ -2,7 +2,8 @@ package com.uwcs446.socialsports.services.match
 
 import com.uwcs446.socialsports.domain.match.MatchType
 import com.uwcs446.socialsports.services.user.UserEntity
-import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
 
 data class MatchEntity(
     val id: String,
@@ -10,7 +11,9 @@ data class MatchEntity(
     val type: MatchType,
     val description: String,
     val host: UserEntity,
-    val time: Instant,
-    val duration: Long, // in mins
-    val players: List<List<UserEntity>>
+    val date: LocalDate,
+    val time: LocalTime,
+    val duration: Long,
+    val teamOne: List<UserEntity>,
+    val teamTwo: List<UserEntity>
 )


### PR DESCRIPTION
As per the discussion:

- matches have two teams now
- teams are made up of users
- moved time-related stuff to `LocalDate`, `LocalTIme` since it fits better with the use case than the more modern Instant