### PR TITLE
Modify mock match function to return an exact number of matches

### DIFF
--- a/app/src/main/java/com/uwcs446/socialsports/ui/find/FindViewModel.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/find/FindViewModel.kt
@@ -11,7 +11,7 @@ class FindViewModel : ViewModel() {
 
     // TODO: update matchList to hold data for all matches
     private val _matchList = MutableLiveData<List<Match>>().apply {
-        this.value = MatchListUtils.genFakeMatchData(3)
+        this.value = MatchListUtils.genFakeMatchData(5)
     }
 
     val matchList: LiveData<List<Match>> = _matchList

--- a/app/src/main/java/com/uwcs446/socialsports/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/home/HomeViewModel.kt
@@ -10,7 +10,7 @@ class HomeViewModel : ViewModel() {
 
     // TODO: update matchList to hold the current user's matches
     private val _userMatchList = MutableLiveData<List<Match>>().apply {
-        this.value = MatchListUtils.genFakeMatchData(1)
+        this.value = MatchListUtils.genFakeMatchData(2)
     }
 
     val userMatchList: LiveData<List<Match>> = _userMatchList

--- a/app/src/main/java/com/uwcs446/socialsports/ui/matchlist/MatchListUtils.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/matchlist/MatchListUtils.kt
@@ -6,66 +6,64 @@ import com.uwcs446.socialsports.domain.user.User
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
+import kotlin.math.min
 
 class MatchListUtils {
-
     companion object {
+        val mockEntries = listOf(
+            Match(
+                id = "1",
+                sport = Sport.SOCCER,
+                title = "Soccer for All!",
+                description = "Soccer for All",
+                date = LocalDate.parse("2021-07-10"),
+                time = LocalTime.parse("12:30:00"),
+                duration = Duration.parse("PT2H"),
+                host = User("1"),
+                teamOne = listOf(User("1")),
+                teamTwo = listOf(User("1"))
+            ),
+            Match(
+                id = "2",
+                sport = Sport.BASKETBALL,
+                title = "Pro Players Only",
+                description = "Pro Players Only",
+                date = LocalDate.parse("2021-07-20"),
+                time = LocalTime.parse("10:00:00"),
+                duration = Duration.parse("PT2H"),
+                host = User("1"),
+                teamOne = listOf(User("1"), User("1")),
+                teamTwo = listOf(User("1"))
+            ),
+            Match(
+                id = "3",
+                sport = Sport.SOCCER,
+                title = "Scarborough Soccer 6v6",
+                description = "Scarborough Soccer 6v6",
+                date = LocalDate.parse("2021-07-17"),
+                time = LocalTime.parse("18:00:00"),
+                duration = Duration.parse("PT1H"),
+                host = User("1"),
+                teamOne = listOf(User("1"), User("1")),
+                teamTwo = listOf(User("1"), User("1"))
+            ),
+            Match(
+                id = "4",
+                sport = Sport.ULTIMATE,
+                title = "Ultimate Frisbee Pickup",
+                description = "Ultimate Frisbee Pickup",
+                date = LocalDate.parse("2021-07-22"),
+                time = LocalTime.parse("15:30:00"),
+                duration = Duration.parse("PT2H"),
+                host = User("1"),
+                teamOne = listOf(User("1"), User("1")),
+                teamTwo = listOf(User("1"), User("1"), User("1"))
+            )
+        )
+
         fun genFakeMatchData(len: Int): List<Match> {
-            val fakeMatchDataList: ArrayList<Match> = arrayListOf()
-            for (i in 1..len) {
-                val entries = listOf(
-                    Match(
-                        id = "1",
-                        sport = Sport.SOCCER,
-                        title = "Soccer for All!",
-                        description = "Soccer for All",
-                        date = LocalDate.parse("2021-07-10"),
-                        time = LocalTime.parse("12:30:00"),
-                        duration = Duration.parse("PT2H"),
-                        host = User("1"),
-                        teamOne = listOf(User("1")),
-                        teamTwo = listOf(User("1"))
-                    ),
-                    Match(
-                        id = "2",
-                        sport = Sport.BASKETBALL,
-                        title = "Pro Players Only",
-                        description = "Pro Players Only",
-                        date = LocalDate.parse("2021-07-20"),
-                        time = LocalTime.parse("10:00:00"),
-                        duration = Duration.parse("PT2H"),
-                        host = User("1"),
-                        teamOne = listOf(User("1"), User("1")),
-                        teamTwo = listOf(User("1"))
-                    ),
-                    Match(
-                        id = "3",
-                        sport = Sport.SOCCER,
-                        title = "Scarborough Soccer 6v6",
-                        description = "Scarborough Soccer 6v6",
-                        date = LocalDate.parse("2021-07-17"),
-                        time = LocalTime.parse("18:00:00"),
-                        duration = Duration.parse("PT1H"),
-                        host = User("1"),
-                        teamOne = listOf(User("1"), User("1")),
-                        teamTwo = listOf(User("1"), User("1"))
-                    ),
-                    Match(
-                        id = "4",
-                        sport = Sport.ULTIMATE,
-                        title = "Ultimate Frisbee Pickup",
-                        description = "Ultimate Frisbee Pickup",
-                        date = LocalDate.parse("2021-07-22"),
-                        time = LocalTime.parse("15:30:00"),
-                        duration = Duration.parse("PT2H"),
-                        host = User("1"),
-                        teamOne = listOf(User("1"), User("1")),
-                        teamTwo = listOf(User("1"), User("1"), User("1"))
-                    )
-                )
-                fakeMatchDataList.addAll(entries)
-            }
-            return fakeMatchDataList
+            val boundedLen = min(mockEntries.size, len)
+            return mockEntries.slice(IntRange(0, boundedLen - 1))
         }
     }
 }

--- a/app/src/main/java/com/uwcs446/socialsports/ui/matchlist/MatchListUtils.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/matchlist/MatchListUtils.kt
@@ -58,6 +58,18 @@ class MatchListUtils {
                 host = User("1"),
                 teamOne = listOf(User("1"), User("1")),
                 teamTwo = listOf(User("1"), User("1"), User("1"))
+            ),
+            Match(
+                id = "5",
+                sport = Sport.SOCCER,
+                title = "UEFA Euro Cup Finals",
+                description = "Italy vs England",
+                date = LocalDate.parse("2021-07-11"),
+                time = LocalTime.parse("15:00:00"),
+                duration = Duration.parse("PT2H"),
+                host = User("1"),
+                teamOne = listOf(User("1"), User("1")),
+                teamTwo = listOf(User("1"), User("1"), User("1"))
             )
         )
 


### PR DESCRIPTION
## Description

This PR changes `genFakeMatchData` so that it accepts an integer which is interpreted as the number of mock matches to return.

Also reduces the number of matches showing up in `home` view to 2 matches, and in the `find` view to 5 matches so as to avoid repeated match entries. This is in preparation for match filtering/sorting functionality I'm going to open in a followup PR - having repeated matches show up will look odd especially once filters are applied.
