### PR TITLE
Require uses to log in before using the app

### DIFF
--- a/app/src/main/java/com/uwcs446/socialsports/MainActivity.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/MainActivity.kt
@@ -62,6 +62,12 @@ class MainActivity :
         mainViewModel.handleAuthChange()
     }
 
+    // Support back button in action bar
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressed();
+        return true;
+    }
+
 //    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
 //        super.onActivityResult(requestCode, resultCode, data)
 //        if (requestCode == RC_SIGN_IN) {

--- a/app/src/main/java/com/uwcs446/socialsports/MainActivity.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/MainActivity.kt
@@ -27,8 +27,6 @@ class MainActivity :
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        UserLoginService.login(this)
-
         val navView: BottomNavigationView = binding.navView
 
         val navController = findNavController(R.id.nav_host_fragment_activity_main)
@@ -44,14 +42,6 @@ class MainActivity :
         navView.setupWithNavController(navController)
     }
 
-    override fun onResume() {
-        // Force login, in case user tries to navigate backwards from the login
-        //  UI to use the app logged-out
-        UserLoginService.login(this)
-
-        super.onResume()
-    }
-
     // TODO CAN USE EITHER AUTHLISTENER OR ACTIVITYRESULT FOR FIRST LOGIN (don't need both)
     override fun onStart() {
         super.onStart()
@@ -60,6 +50,9 @@ class MainActivity :
 
     override fun onAuthStateChanged(auth: FirebaseAuth) {
         mainViewModel.handleAuthChange()
+
+        // This forces the user to log in, so that they can't use the app logged out.
+        UserLoginService.login(this)
     }
 
     // Support back button in action bar

--- a/app/src/main/java/com/uwcs446/socialsports/MainActivity.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/MainActivity.kt
@@ -57,8 +57,8 @@ class MainActivity :
 
     // Support back button in action bar
     override fun onSupportNavigateUp(): Boolean {
-        onBackPressed();
-        return true;
+        onBackPressed()
+        return true
     }
 
 //    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/app/src/main/java/com/uwcs446/socialsports/MainActivity.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/MainActivity.kt
@@ -44,7 +44,13 @@ class MainActivity :
         navView.setupWithNavController(navController)
     }
 
-    override fun onBackPressed() {} // TODO explore further to avoid not signing in
+    override fun onResume() {
+        // Force login, in case user tries to navigate backwards from the login
+        //  UI to use the app logged-out
+        UserLoginService.login(this)
+
+        super.onResume()
+    }
 
     // TODO CAN USE EITHER AUTHLISTENER OR ACTIVITYRESULT FOR FIRST LOGIN (don't need both)
     override fun onStart() {

--- a/app/src/main/java/com/uwcs446/socialsports/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/profile/ProfileFragment.kt
@@ -10,7 +10,6 @@ import androidx.fragment.app.viewModels
 import com.google.android.gms.maps.model.LatLng
 import com.uwcs446.socialsports.databinding.FragmentProfileBinding
 import com.uwcs446.socialsports.services.LocationService
-import com.uwcs446.socialsports.services.user.UserLoginService
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -34,10 +33,7 @@ class ProfileFragment : Fragment() {
         _binding = FragmentProfileBinding.inflate(inflater, container, false)
         val root: View = binding.root
 
-        binding.logoutButton.setOnClickListener {
-            viewModel.handleLogout()
-            UserLoginService.login(requireActivity())
-        }
+        binding.logoutButton.setOnClickListener { viewModel.handleLogout() }
 
         val textView: TextView = binding.textProfile
         viewModel.text.observe(

--- a/app/src/main/java/com/uwcs446/socialsports/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/profile/ProfileFragment.kt
@@ -34,8 +34,10 @@ class ProfileFragment : Fragment() {
         _binding = FragmentProfileBinding.inflate(inflater, container, false)
         val root: View = binding.root
 
-        binding.logoutButton.setOnClickListener { viewModel.handleLogout() }
-        binding.loginButton.setOnClickListener { UserLoginService.login(requireActivity()) }
+        binding.logoutButton.setOnClickListener {
+            viewModel.handleLogout()
+            UserLoginService.login(requireActivity())
+        }
 
         val textView: TextView = binding.textProfile
         viewModel.text.observe(

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -30,13 +30,4 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <Button
-        android:id="@+id/loginButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="60dp"
-        android:layout_marginEnd="10dp"
-        android:text="@string/login"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Description

This PR includes three changes:
1. Resolves TODO by forcing users to log in
2. Removes the `Login` button, since the `Logout` button brings up the login Auth UI
3. Add support for back buttons in the UI

## Demos

The following GIF exhibits items 1 and 2

![demo1](https://user-images.githubusercontent.com/11084174/126062579-18bf7af1-6038-435f-8a68-e1cc7008d5aa.gif)

The following exhibits item 3

![demo2](https://user-images.githubusercontent.com/11084174/126062581-42ab90df-d12e-410f-a43e-7b0ecffff897.gif)
