### PR TITLE
Don't use LiveData for fetching Games

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-database-ktx'
     implementation 'com.firebaseui:firebase-ui-auth:7.1.1'
     implementation 'com.firebase:geofire-android-common:3.1.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.5.1'
 
     //google maps
     implementation 'com.google.maps.android:maps-ktx:2.3.0'

--- a/app/src/main/java/com/uwcs446/socialsports/domain/match/MatchRepository.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/domain/match/MatchRepository.kt
@@ -8,7 +8,7 @@ interface MatchRepository {
 
     val matchesByHost: LiveData<Pair<String, List<Match>>>
 
-    fun fetchExploreMatches(sport: Sport)
+    suspend fun fetchExploreMatches(sport: Sport): List<Match>?
 
     fun findAllByHost(hostId: String)
 

--- a/app/src/main/java/com/uwcs446/socialsports/services/match/FirebaseMatchRepository.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/services/match/FirebaseMatchRepository.kt
@@ -12,6 +12,8 @@ import com.uwcs446.socialsports.domain.match.Match
 import com.uwcs446.socialsports.domain.match.MatchRepository
 import com.uwcs446.socialsports.domain.match.Sport
 import com.uwcs446.socialsports.services.user.UserEntity
+import kotlinx.coroutines.tasks.await
+import java.lang.Exception
 import javax.inject.Inject
 
 class FirebaseMatchRepository
@@ -32,43 +34,28 @@ class FirebaseMatchRepository
 
     override val matchesByHost: LiveData<Pair<String, List<Match>>> = _matchesByHost
 
-    override fun fetchExploreMatches(sport: Sport) {
-        matchesCollection
-            .get()
-            .addOnSuccessListener { matchResult ->
-                val matches = matchResult
-                    .documents
-                    .mapNotNull {
-                        it.toMatchEntity()
-                    }
-                    .filter { match ->
-                        sport == Sport.ANY || match.sport == sport
-                    }
-                usersCollection
-                    .whereIn(
-                        UserEntity::id.name,
-                        allUsersFromMatches(matches)
-                    )
-                    .get()
-                    .addOnSuccessListener { usersResult ->
-                        val users = usersResult
-                            .documents
-                            .mapNotNull {
-                                it.toUserEntity()
-                            }
-
-                        _exploreMatches.postValue(
-                            matches.toDomain(users)
-                        )
-                            .also { Log.d(TAG, "Retrieved ${matches.size} explore matches") }
-                    }
-                    .addOnFailureListener { e ->
-                        Log.d(TAG, "Something went wrong fetching users", e)
-                    }
+    override suspend fun fetchExploreMatches(sport: Sport): List<Match>? {
+        try {
+            val matches = matchesCollection
+                .whereIn(Match::sport.name, if (sport == Sport.ANY) Sport.values().toList() else listOf(sport))
+                .get()
+                .await()
+                .documents
+                .mapNotNull { document -> document.toMatchEntity() }
+            if (matches.isEmpty()) {
+                return emptyList()
             }
-            .addOnFailureListener { e ->
-                Log.d(TAG, "Something went wrong fetching explore matches", e)
-            }
+            val users = usersCollection
+                .whereIn(UserEntity::id.name, allUsersFromMatches(matches))
+                .get().await()
+                .documents
+                .mapNotNull { user -> user.toUserEntity() }
+            Log.d(TAG, "Found ${matches.size} matches")
+            return matches.toDomain(users)
+        } catch (e: Exception) {
+            Log.e(TAG, "Something went wrong while fetching explore matches", e)
+        }
+        return null
     }
 
     override fun findAllByHost(hostId: String) {

--- a/app/src/main/java/com/uwcs446/socialsports/ui/find/FindFragment.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/find/FindFragment.kt
@@ -82,7 +82,7 @@ class FindFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         // Observer which updates the recyclerview when match data changes
-        findViewModel.matchList.observe(viewLifecycleOwner) { matchList ->
+        findViewModel.matches.observe(viewLifecycleOwner) { matchList ->
             recyclerViewData.clear()
             recyclerViewData.addAll(matchList)
             recyclerViewAdapter.notifyDataSetChanged()

--- a/app/src/main/java/com/uwcs446/socialsports/ui/find/FindViewModel.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/find/FindViewModel.kt
@@ -1,11 +1,14 @@
 package com.uwcs446.socialsports.ui.find
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.uwcs446.socialsports.domain.match.Match
 import com.uwcs446.socialsports.domain.match.MatchRepository
 import com.uwcs446.socialsports.domain.match.Sport
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -14,10 +17,14 @@ class FindViewModel @Inject constructor(
     val matchRepository: MatchRepository,
 ) : ViewModel() {
 
-    val matchList: LiveData<List<Match>> = matchRepository.exploreMatches
+    val _matches = MutableLiveData<List<Match>>(emptyList())
+
+    val matches: LiveData<List<Match>> = _matches
 
     init {
-        matchRepository.fetchExploreMatches(Sport.ANY)
+        viewModelScope.launch {
+            _matches.value = matchRepository.fetchExploreMatches(Sport.ANY)
+        }
     }
 
     // TODO: filter match by date, remove filtering if time is null
@@ -27,9 +34,9 @@ class FindViewModel @Inject constructor(
     fun filterMatchByTime(hour: Int, minute: Int) {}
 
     /**
-     * Filters matches by sport. Shows all matches if sport is `null`.
+     * Filters matches by sport.
      */
     fun filterMatchBySport(sport: Sport) {
-        matchRepository.fetchExploreMatches(sport)
+        _matches.value = _matches.value?.filter { match -> sport == Sport.ANY || match.sport == sport }
     }
 }

--- a/app/src/main/java/com/uwcs446/socialsports/ui/find/FindViewModel.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/find/FindViewModel.kt
@@ -14,7 +14,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class FindViewModel @Inject constructor(
-    val matchRepository: MatchRepository,
+    private val matchRepository: MatchRepository,
 ) : ViewModel() {
 
     val _matches = MutableLiveData<List<Match>>(emptyList())


### PR DESCRIPTION
Switching to using Kotlin coroutines for the Firebase Repository. Allows us to remove LiveData from the repository. I've only done this for the method that matters for Find Game.