### PR TITLE
Fix inconsistent My Games filtering

### DIFF
--- a/app/src/main/java/com/uwcs446/socialsports/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/home/HomeFragment.kt
@@ -33,7 +33,7 @@ class HomeFragment : Fragment() {
         _binding = FragmentHomeBinding.inflate(inflater, container, false)
 
         // set up recycler view for match list
-        binding.layoutMatchList.recyclerviewMatch.setHasFixedSize(true)
+        binding.layoutMatchList.recyclerviewMatch.setHasFixedSize(false)
         binding.layoutMatchList.recyclerviewMatch.layoutManager = LinearLayoutManager(requireContext(), RecyclerView.VERTICAL, false)
         binding.layoutMatchList.recyclerviewMatch.adapter = recyclerViewAdapter
 
@@ -56,31 +56,31 @@ class HomeFragment : Fragment() {
             binding.layoutHomeFilterToolbar.toggleButtonPastMatches
         )
 
+        homeViewModel.filterType.observe(viewLifecycleOwner) { filterType ->
+            toggleButtons.forEach { it.isChecked = false }
+            when (filterType) {
+                MatchFilter.JOINED ->
+                    binding.layoutHomeFilterToolbar.toggleButtonJoinedMatches.isChecked = true
+                MatchFilter.HOSTING ->
+                    binding.layoutHomeFilterToolbar.toggleButtonHostingMatches.isChecked = true
+                MatchFilter.PAST ->
+                    binding.layoutHomeFilterToolbar.toggleButtonPastMatches.isChecked = true
+            }
+        }
+
         // Set up toggle button listeners
         toggleButtons.forEach { button ->
-            // Ensure that exactly one toggle button is active at a time
-            button.setOnClickListener {
-                for (toggleButton in toggleButtons) {
-                    toggleButton.isChecked = false || toggleButton == button
-                }
-            }
-
             // Filter matches based on toggle selection
             button.setOnCheckedChangeListener { _button, checked ->
-                val filter = MatchFilter.values().find { filter ->
-                    filter.toString() == _button.text
-                }
+                val filter = MatchFilter.values().find { it.toString() == _button.text }
                 if (checked) {
                     binding.homeProgressBar.visibility = VISIBLE
                     binding.layoutMatchList.recyclerviewMatch.visibility = INVISIBLE
 
-                    homeViewModel.filterMatches(filter!!)
+                    homeViewModel.setFilterType(filter!!)
                 }
             }
         }
-
-        // Default match filtering is to view joined matches
-        binding.layoutHomeFilterToolbar.toggleButtonJoinedMatches.isChecked = true
 
         return binding.root
     }

--- a/app/src/main/java/com/uwcs446/socialsports/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/home/HomeViewModel.kt
@@ -20,8 +20,10 @@ class HomeViewModel @Inject constructor(
     private val currentUser = currentUserRepository.getUser()
 
     private val _matches = MutableLiveData<List<Match>>(emptyList())
-
     val matches: LiveData<List<Match>> = _matches
+
+    private val _filterType = MutableLiveData(MatchFilter.JOINED)
+    val filterType: LiveData<MatchFilter> = _filterType
 
     init {
         if (currentUser != null) {
@@ -31,7 +33,14 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun filterMatches(filter: MatchFilter) {
+    fun setFilterType(filter: MatchFilter) {
+        filterMatches(filter)
+
+        if (_filterType.value == filter) return
+        _filterType.value = filter
+    }
+
+    private fun filterMatches(filter: MatchFilter) {
         if (currentUser == null) {
             _matches.value = matches.value // no-op
             return


### PR DESCRIPTION
## Description

This PR refactors My Games filtering to be stateful, keeping track of the currently active `MatchFilter` in the view model and attaching an observer to the live data to update the filter buttons.

This also fixes a bug where if you filtered by `Hosting`, viewed match details, then pressed the back button, the `Hosting` button would be active, but the recycler view would show `Joined` games.

