### PR TITLE
Fix bug for game edit

### DIFF
--- a/app/src/main/java/com/uwcs446/socialsports/ui/matchdetails/MatchDetailsViewModel.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/matchdetails/MatchDetailsViewModel.kt
@@ -105,6 +105,7 @@ class MatchDetailsViewModel @Inject constructor(
 
     // check whether the current user is the match host and update isHost accordingly
     private fun checkHost(hostId: String) {
+        val currentUser = currentUserRepository.getUser()
         if (currentUser != null) {
             _isHost.value = (hostId == currentUser.uid)
         } else {


### PR DESCRIPTION
Fix a bug where after signing into a different account, the current logged in user's id remains to be the previous user's id when checking for game host