### PR TITLE
[SFA-58] [SFA-70] Notification System

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,9 @@
             android:name=".receivers.RateReminderBroadcast"
             android:enabled="true"
             android:exported="true" />
-
+        <activity
+            android:name=".ui.matchrating.MatchRating"
+            android:parentActivityName=".MainActivity" />
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,11 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.SocialSports">
+        <receiver
+            android:name=".receivers.RateReminderBroadcast"
+            android:enabled="true"
+            android:exported="true" />
+
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name">

--- a/app/src/main/java/com/uwcs446/socialsports/receivers/RateReminderBroadcast.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/receivers/RateReminderBroadcast.kt
@@ -25,19 +25,19 @@ class RateReminderBroadcast : BroadcastReceiver() {
         }
         // we use notification compat builder to construct the details of our notification
         val builder = NotificationCompat.Builder(
-                context,
-                context.getString(R.string.match_rating_notification_channel_id)
+            context,
+            context.getString(R.string.match_rating_notification_channel_id)
         )
-                .setContentIntent(resultPendingIntent)
-                .setSmallIcon(R.drawable.ic_baseline_sports_24)
-                .setContentTitle("Rate your match!")
-                .setContentText("How was your game?")
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(resultPendingIntent)
+            .setSmallIcon(R.drawable.ic_baseline_sports_24)
+            .setContentTitle("Rate your match!")
+            .setContentText("How was your game?")
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
 
         // call the static function from(Context) to get a NotificationManagerCompat object, and then call one of its methods to post or cancel notifications.
         val notificationManager = NotificationManagerCompat.from(context)
 
         // Post a notification to be shown in the status bar, stream, etc.
-        notificationManager.notify(200, builder.build());
+        notificationManager.notify(200, builder.build())
     }
 }

--- a/app/src/main/java/com/uwcs446/socialsports/receivers/RateReminderBroadcast.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/receivers/RateReminderBroadcast.kt
@@ -1,0 +1,43 @@
+package com.uwcs446.socialsports.receivers
+
+import android.app.PendingIntent
+import android.app.TaskStackBuilder
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.uwcs446.socialsports.R
+import com.uwcs446.socialsports.ui.matchrating.MatchRating
+
+class RateReminderBroadcast : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        // Create an Intent for the activity you want to start
+        val resultIntent = Intent(context, MatchRating::class.java)
+        resultIntent.putExtra("MatchId", intent.getSerializableExtra("MatchId"))
+        // Create the TaskStackBuilder
+        val resultPendingIntent: PendingIntent? = TaskStackBuilder.create(context).run {
+            // Add the intent, which inflates the back stack
+            addNextIntentWithParentStack(resultIntent)
+            // Get the PendingIntent containing the entire back stack
+            getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT)
+        }
+        // we use notification compat builder to construct the details of our notification
+        val builder = NotificationCompat.Builder(
+                context,
+                context.getString(R.string.match_rating_notification_channel_id)
+        )
+                .setContentIntent(resultPendingIntent)
+                .setSmallIcon(R.drawable.ic_baseline_sports_24)
+                .setContentTitle("Rate your match!")
+                .setContentText("How was your game?")
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+
+        // call the static function from(Context) to get a NotificationManagerCompat object, and then call one of its methods to post or cancel notifications.
+        val notificationManager = NotificationManagerCompat.from(context)
+
+        // Post a notification to be shown in the status bar, stream, etc.
+        notificationManager.notify(200, builder.build());
+    }
+}

--- a/app/src/main/java/com/uwcs446/socialsports/ui/matchrating/MatchRating.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/matchrating/MatchRating.kt
@@ -1,8 +1,8 @@
 package com.uwcs446.socialsports.ui.matchrating
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
 import com.uwcs446.socialsports.R
 
 class MatchRating : AppCompatActivity() {

--- a/app/src/main/java/com/uwcs446/socialsports/ui/matchrating/MatchRating.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/matchrating/MatchRating.kt
@@ -1,0 +1,17 @@
+package com.uwcs446.socialsports.ui.matchrating
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.util.Log
+import com.uwcs446.socialsports.R
+
+class MatchRating : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_match_rating)
+        val matchId = intent.getStringExtra("MatchId")
+        if (matchId != null) {
+            Log.d("match-rating-id", matchId)
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_baseline_sports_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_sports_24.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M11.23,6C9.57,6 8.01,6.66 6.87,7.73C6.54,6.73 5.61,6 4.5,6C3.12,6 2,7.12 2,8.5C2,9.88 3.12,11 4.5,11c0.21,0 0.41,-0.03 0.61,-0.08c-0.05,0.25 -0.09,0.51 -0.1,0.78c-0.18,3.68 2.95,6.68 6.68,6.27c2.55,-0.28 4.68,-2.26 5.19,-4.77c0.15,-0.71 0.15,-1.4 0.06,-2.06c-0.09,-0.6 0.38,-1.13 0.99,-1.13H22V6H11.23zM4.5,9C4.22,9 4,8.78 4,8.5C4,8.22 4.22,8 4.5,8S5,8.22 5,8.5C5,8.78 4.78,9 4.5,9zM11,15c-1.66,0 -3,-1.34 -3,-3s1.34,-3 3,-3s3,1.34 3,3S12.66,15 11,15z"/>
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M11,12m-2,0a2,2 0,1 1,4 0a2,2 0,1 1,-4 0"/>
+</vector>

--- a/app/src/main/res/layout/activity_match_rating.xml
+++ b/app/src/main/res/layout/activity_match_rating.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.matchrating.MatchRating">
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
# Preface

- A notification channel was added to a notification manager in the main activity via PR #67 

# This PR
- Uses an `AlarmManger` to trigger a broadcast receiver `RateReminderBroadcast` at time `match.endTime`.
  - `RateReminderBroadcast`  is passed as a pending intent along with a `match.id` so that we can use the match id in the future (in MatchRatingActivity)
- The broadcast receiver will then display the pop-up notification to the device (at the match end-time), and upon clicking it, it will open the `MatchRatingActivity`.
- The `MatchRatingActivity` can only be accessed through notifications
- Upon clicking back from `MatchRatingActivity`, it will take you to `MainActivity` using a back stack.

# Side Note
- The notification will not happen exactly at the endTime, as the system will decide when it is best to do so.
- I usually saw ~ +30-60 additional seconds
- Users will still get a notification even when the app is completely closed

# Code
- See inline comments for more or ask questions

# Gif
- I set a match with a duration of 1 minute. Mind the accidental click I did while waiting for the notification ~~
![Gif](https://user-images.githubusercontent.com/15854649/128268933-f7d0ad8b-4ffd-428d-8fb7-3aa34d0fee19.gif)

# Future PR
- Expect a future PR for handling the Rating System through this newly created `MatchRatingActivity`
