### PR TITLE
Fix bug where home fragment doesn't load on login

### DIFF
--- a/app/src/main/java/com/uwcs446/socialsports/MainActivity.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/MainActivity.kt
@@ -23,7 +23,6 @@ import com.google.firebase.auth.FirebaseAuth
 import com.uwcs446.socialsports.databinding.ActivityMainBinding
 import com.uwcs446.socialsports.services.user.UserLoginService
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 import java.util.Locale
 
 @AndroidEntryPoint

--- a/app/src/main/java/com/uwcs446/socialsports/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/home/HomeFragment.kt
@@ -80,9 +80,18 @@ class HomeFragment : Fragment() {
                     homeViewModel.setFilterType(filter!!)
                 }
             }
+
+            button.setOnClickListener {
+                toggleButtons.forEach { it.isChecked = false || it == button }
+            }
         }
 
         return binding.root
+    }
+
+    override fun onResume() {
+        super.onResume()
+        homeViewModel.handleOnResume()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/uwcs446/socialsports/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/home/HomeViewModel.kt
@@ -20,8 +20,6 @@ class HomeViewModel @Inject constructor(
     private val locationService: LocationService
 ) : ViewModel() {
 
-    private val currentUser = currentUserRepository.getUser()
-
     private val _matchPlaces = MutableLiveData<List<Pair<Match, Place>>>(emptyList())
     val matchPlaces: LiveData<List<Pair<Match, Place>>> = _matchPlaces
 
@@ -35,7 +33,13 @@ class HomeViewModel @Inject constructor(
         _filterType.value = filter
     }
 
+    fun handleOnResume() {
+        filterMatches(_filterType.value!!)
+    }
+
     private fun filterMatches(filter: MatchFilter) {
+        val currentUser = currentUserRepository.getUser()
+
         if (currentUser == null) {
             _matchPlaces.value = _matchPlaces.value // no-op
             return


### PR DESCRIPTION
Title.

This PR fixes the bug where on initial login, the home fragment does not show matches, since it's inflated before the user is authenticated, so the current user is initially null.

Also fixes a visual bug where home fragment match filtering buttons can get "unchecked".
