### PR TITLE
Fix Bug: Make profile Fragment's Rating Bar un-Adjustable (An Indicator)

### DIFF
--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -38,6 +38,7 @@
          app:layout_constraintEnd_toEndOf="parent"
          app:layout_constraintStart_toStartOf="parent"
          app:layout_constraintTop_toBottomOf="@+id/user_profile_username"
+         android:isIndicator="true"
          android:progressTint="@color/purple_500"
          android:progressBackgroundTint="@color/grey"/>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15854649/128615442-514cd1e9-3937-4bbe-8918-3881850ca09a.png)

- The rating bar in the profile fragment was adjustable.. simply made it un-adjustable in this pr 
- For reference: https://developer.android.com/reference/android/widget/RatingBar