### PR TITLE
Hide Join Button for Games in the Past

### DIFF
--- a/app/src/main/java/com/uwcs446/socialsports/domain/user/User.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/domain/user/User.kt
@@ -7,4 +7,6 @@ import kotlinx.android.parcel.Parcelize
 data class User(
     val id: String,
     val name: String,
+    val rating: Float,
+    val numRatings: Int,
 ) : Parcelable

--- a/app/src/main/java/com/uwcs446/socialsports/receivers/RateReminderBroadcast.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/receivers/RateReminderBroadcast.kt
@@ -14,14 +14,15 @@ class RateReminderBroadcast : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         // Create an Intent for the activity you want to start
+        val matchId = intent.getStringExtra("MatchId")
         val resultIntent = Intent(context, MatchRatingActivity::class.java)
-        resultIntent.putExtra("MatchId", intent.getSerializableExtra("MatchId"))
+        resultIntent.putExtra("MatchId", matchId)
         // Create the TaskStackBuilder
         val resultPendingIntent: PendingIntent? = TaskStackBuilder.create(context).run {
             // Add the intent, which inflates the back stack
             addNextIntentWithParentStack(resultIntent)
             // Get the PendingIntent containing the entire back stack
-            getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT)
+            getPendingIntent(0, PendingIntent.FLAG_CANCEL_CURRENT)
         }
         // we use notification compat builder to construct the details of our notification
         val builder = NotificationCompat.Builder(

--- a/app/src/main/java/com/uwcs446/socialsports/services/user/UserAssembler.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/services/user/UserAssembler.kt
@@ -5,13 +5,17 @@ import com.uwcs446.socialsports.domain.user.User
 fun User.toEntity() =
     UserEntity(
         id = id,
-        name = name
+        name = name,
+        rating = rating,
+        numRatings = numRatings
     )
 
 fun UserEntity.toDomain() =
     User(
         id = id,
-        name = name
+        name = name,
+        rating = rating,
+        numRatings = numRatings
     )
 
 fun Collection<UserEntity>.toDomain() = this.map { it.toDomain() }

--- a/app/src/main/java/com/uwcs446/socialsports/services/user/UserEntity.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/services/user/UserEntity.kt
@@ -4,5 +4,7 @@ import java.util.UUID
 
 data class UserEntity(
     val id: String = UUID.randomUUID().toString(),
-    val name: String = ""
+    val name: String = "",
+    val rating: Float = 0F,
+    val numRatings: Int = 0
 )

--- a/app/src/main/java/com/uwcs446/socialsports/services/user/current/FirebaseCurrentUserRepository.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/services/user/current/FirebaseCurrentUserRepository.kt
@@ -51,6 +51,6 @@ class FirebaseCurrentUserRepository
     private suspend fun upsertUserCollection() {
         val currentUser = firebaseAuth.currentUser
         if (currentUser != null)
-            userRepository.upsert(User(currentUser.uid, currentUser.displayName ?: "NO_NAME", 0F,0))
+            userRepository.upsert(User(currentUser.uid, currentUser.displayName ?: "NO_NAME", 0F, 0))
     }
 }

--- a/app/src/main/java/com/uwcs446/socialsports/services/user/current/FirebaseCurrentUserRepository.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/services/user/current/FirebaseCurrentUserRepository.kt
@@ -51,6 +51,6 @@ class FirebaseCurrentUserRepository
     private suspend fun upsertUserCollection() {
         val currentUser = firebaseAuth.currentUser
         if (currentUser != null)
-            userRepository.upsert(User(currentUser.uid, currentUser.displayName ?: "NO_NAME"))
+            userRepository.upsert(User(currentUser.uid, currentUser.displayName ?: "NO_NAME", 0F,0))
     }
 }

--- a/app/src/main/java/com/uwcs446/socialsports/ui/matchdetails/MatchDetailsFragment.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/matchdetails/MatchDetailsFragment.kt
@@ -161,59 +161,64 @@ class MatchDetailsFragment : Fragment() {
                         if (teamTwo != null) teamTwoViewAdapter.updateTeamMembers(teamTwo.map { user -> user.name })
 
                         // Enable or disable join buttons
-                        if (matchDetailsViewModel.isInTeam(1)) {
-                            // Enable leave team one button
-                            binding.matchTeamOneJoinButton.text = "Leave"
-                            binding.matchTeamOneJoinButton.isEnabled = true
-                            binding.matchTeamOneJoinButton.setOnClickListener {
-                                matchDetailsViewModel.leaveMatch(
-                                    1
-                                )
-                            }
-                            // Disable join team two button
-                            binding.matchTeamTwoJoinButton.text = "Join"
-                            binding.matchTeamTwoJoinButton.isEnabled = false
-                            binding.matchTeamTwoJoinButton.setOnClickListener {
-                                matchDetailsViewModel.joinMatch(
-                                    2
-                                )
-                            }
-                        } else if (matchDetailsViewModel.isInTeam(2)) {
-                            // Disable join team one button
-                            binding.matchTeamOneJoinButton.text = "Join"
-                            binding.matchTeamOneJoinButton.isEnabled = false
-                            binding.matchTeamOneJoinButton.setOnClickListener {
-                                matchDetailsViewModel.joinMatch(
-                                    1
-                                )
-                            }
-                            // Enable leave team two button
-                            binding.matchTeamTwoJoinButton.text = "Leave"
-                            binding.matchTeamTwoJoinButton.isEnabled = true
-                            binding.matchTeamTwoJoinButton.setOnClickListener {
-                                matchDetailsViewModel.leaveMatch(
-                                    2
-                                )
+                        if (match.startTime.isAfter(Instant.now())) {
+                            if (matchDetailsViewModel.isInTeam(1)) {
+                                // Enable leave team one button
+                                binding.matchTeamOneJoinButton.text = "Leave"
+                                binding.matchTeamOneJoinButton.isEnabled = true
+                                binding.matchTeamOneJoinButton.setOnClickListener {
+                                    matchDetailsViewModel.leaveMatch(
+                                        1
+                                    )
+                                }
+                                // Disable join team two button
+                                binding.matchTeamTwoJoinButton.text = "Join"
+                                binding.matchTeamTwoJoinButton.isEnabled = false
+                                binding.matchTeamTwoJoinButton.setOnClickListener {
+                                    matchDetailsViewModel.joinMatch(
+                                        2
+                                    )
+                                }
+                            } else if (matchDetailsViewModel.isInTeam(2)) {
+                                // Disable join team one button
+                                binding.matchTeamOneJoinButton.text = "Join"
+                                binding.matchTeamOneJoinButton.isEnabled = false
+                                binding.matchTeamOneJoinButton.setOnClickListener {
+                                    matchDetailsViewModel.joinMatch(
+                                        1
+                                    )
+                                }
+                                // Enable leave team two button
+                                binding.matchTeamTwoJoinButton.text = "Leave"
+                                binding.matchTeamTwoJoinButton.isEnabled = true
+                                binding.matchTeamTwoJoinButton.setOnClickListener {
+                                    matchDetailsViewModel.leaveMatch(
+                                        2
+                                    )
+                                }
+                            } else {
+                                // Enable join team one button
+                                binding.matchTeamOneJoinButton.text = "Join"
+                                binding.matchTeamOneJoinButton.isEnabled = true
+                                binding.matchTeamOneJoinButton.setOnClickListener {
+                                    matchDetailsViewModel.joinMatch(
+                                        1
+                                    )
+                                    rateReminderCallback(match.id, endTimeInMillis)
+                                }
+                                // Enable join team two button
+                                binding.matchTeamTwoJoinButton.text = "Join"
+                                binding.matchTeamTwoJoinButton.isEnabled = true
+                                binding.matchTeamTwoJoinButton.setOnClickListener {
+                                    matchDetailsViewModel.joinMatch(
+                                        2
+                                    )
+                                    rateReminderCallback(match.id, endTimeInMillis)
+                                }
                             }
                         } else {
-                            // Enable join team one button
-                            binding.matchTeamOneJoinButton.text = "Join"
-                            binding.matchTeamOneJoinButton.isEnabled = true
-                            binding.matchTeamOneJoinButton.setOnClickListener {
-                                matchDetailsViewModel.joinMatch(
-                                    1
-                                )
-                                rateReminderCallback(match.id, endTimeInMillis)
-                            }
-                            // Enable join team two button
-                            binding.matchTeamTwoJoinButton.text = "Join"
-                            binding.matchTeamTwoJoinButton.isEnabled = true
-                            binding.matchTeamTwoJoinButton.setOnClickListener {
-                                matchDetailsViewModel.joinMatch(
-                                    2
-                                )
-                                rateReminderCallback(match.id, endTimeInMillis)
-                            }
+                            binding.matchTeamOneJoinButton.visibility = GONE
+                            binding.matchTeamTwoJoinButton.visibility = GONE
                         }
 
                         // Switch visibility of views
@@ -221,7 +226,7 @@ class MatchDetailsFragment : Fragment() {
                         binding.matchDetailsViews.visibility = VISIBLE
 
                         if (isHost && match.startTime.isAfter(Instant.now())) {
-                            // display the edit button if current user is the match host
+                            // display the edit button if current user is the match host and the game is in the future
                             binding.editButtonMatchDetails.visibility = VISIBLE
                             binding.editButtonMatchDetails.setOnClickListener {
                                 val action =

--- a/app/src/main/java/com/uwcs446/socialsports/ui/matchdetails/MatchDetailsFragment.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/matchdetails/MatchDetailsFragment.kt
@@ -120,7 +120,7 @@ class MatchDetailsFragment : Fragment() {
                             // Passing the matchId so the MatchRatingActivity will know the match it is dealing with
                             intent.putExtra("MatchId", matchId)
                             // Pending intent, will trigger the RateReminderBroadcast
-                            val pendingIntent = PendingIntent.getBroadcast(context, 0, intent, 0)
+                            val pendingIntent = PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT)
                             val alarmManager = context?.getSystemService(Context.ALARM_SERVICE) as? AlarmManager
 
                             // Using alarm manager to trigger a notification via broadcast receiver after the game is done

--- a/app/src/main/java/com/uwcs446/socialsports/ui/matchrating/MatchRatingActivity.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/matchrating/MatchRatingActivity.kt
@@ -1,17 +1,21 @@
 package com.uwcs446.socialsports.ui.matchrating
 
 import android.os.Bundle
-import android.util.Log
 import android.widget.Button
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.widget.ViewPager2
 import com.uwcs446.socialsports.R
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.android.synthetic.main.activity_match_rating.*
+import kotlinx.coroutines.launch
 import me.relex.circleindicator.CircleIndicator3
 
+@AndroidEntryPoint
 class MatchRatingActivity : AppCompatActivity() {
 
-    private var userNameList = mutableListOf<String>()
+    private val matchRatingViewModel: MatchRatingViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -21,33 +25,36 @@ class MatchRatingActivity : AppCompatActivity() {
         actionBar?.setDisplayHomeAsUpEnabled(false)
 
         val matchId = intent.getStringExtra("MatchId")
-        if (matchId != null) {
-            Log.d("match-rating-id", matchId)
+
+        lifecycleScope.launch {
+            matchRatingViewModel.fetchMatchPlayers(matchId!!)
         }
 
-        postDummyToList()
+        matchRatingViewModel.ready.observe(
+            this,
+            { ready ->
+                if (ready) {
 
-        view_pager2.adapter = ViewPagerAdapter(userNameList)
-        view_pager2.orientation = ViewPager2.ORIENTATION_HORIZONTAL
+                    val players = matchRatingViewModel.players.value
 
-        val indicator = findViewById<CircleIndicator3>(R.id.indicator)
-        val submitRatingButton: Button = findViewById(R.id.submit_rating_button)
-        // Hook up indicator with the view pager
-        indicator.setViewPager(view_pager2)
+                    val matchRatingAdapter = players?.let { ViewPagerAdapter(it) }
+                    view_pager2.adapter = matchRatingAdapter
+                    view_pager2.orientation = ViewPager2.ORIENTATION_HORIZONTAL
 
-        // OnSubmit go home fragment
-        submitRatingButton.setOnClickListener {
-            finish()
-        }
-    }
+                    val indicator = findViewById<CircleIndicator3>(R.id.indicator)
+                    val submitRatingButton: Button = findViewById(R.id.submit_rating_button)
+                    // Hook up indicator with the view pager
+                    indicator.setViewPager(view_pager2)
 
-    private fun addToList(userName: String) {
-        userNameList.add(userName)
-    }
-
-    private fun postDummyToList() {
-        for (i in 1..5) {
-            addToList("Name $i")
-        }
+                    // OnSubmit go home fragment
+                    submitRatingButton.setOnClickListener {
+                        if (matchRatingAdapter != null) {
+                            matchRatingViewModel.ratePlayers(matchRatingAdapter.getPlayerRatingList())
+                        }
+                        finish()
+                    }
+                }
+            }
+        )
     }
 }

--- a/app/src/main/java/com/uwcs446/socialsports/ui/matchrating/MatchRatingViewModel.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/matchrating/MatchRatingViewModel.kt
@@ -1,0 +1,58 @@
+package com.uwcs446.socialsports.ui.matchrating
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.uwcs446.socialsports.domain.match.MatchRepository
+import com.uwcs446.socialsports.domain.user.CurrentAuthUserRepository
+import com.uwcs446.socialsports.domain.user.User
+import com.uwcs446.socialsports.domain.user.UserRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MatchRatingViewModel @Inject constructor (
+    private val matchRepository: MatchRepository,
+    private val userRepository: UserRepository,
+    private val currentUserRepository: CurrentAuthUserRepository
+) : ViewModel() {
+
+    private val currentUser = currentUserRepository.getUser()
+
+    private val _players = MutableLiveData<List<User>>(emptyList())
+    val players: LiveData<List<User>> = _players
+
+    private val _ready = MutableLiveData(false)
+    val ready: LiveData<Boolean> = _ready
+
+    suspend fun fetchMatchPlayers(matchId: String) {
+        _ready.value = false
+
+        val fetchedMatch = matchRepository.fetchMatchById(matchId)
+        if (fetchedMatch != null) {
+            val fetchedTeamOne = userRepository.findByIds(fetchedMatch.teamOne)
+
+            val fetchedTeamTwo = userRepository.findByIds(fetchedMatch.teamTwo)
+
+            _players.value = (fetchedTeamOne + fetchedTeamTwo).filter {
+                it.id != currentUser?.uid ?: false
+            }
+            _ready.value = true
+        }
+    }
+
+    // should we add suspend here?
+    fun ratePlayers(playerRatings: MutableList<Float>) {
+        viewModelScope.launch {
+            playerRatings.forEachIndexed { index, rating ->
+                if (rating != 0F) {
+                    val user = _players.value?.get(index)!!
+                    val userUpdated = User(user.id, user.name, ((user.rating * user.numRatings) + rating) / (user.numRatings + 1), user.numRatings + 1)
+                    userRepository.upsert(userUpdated)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/uwcs446/socialsports/ui/matchrating/ViewPagerAdapter.kt
+++ b/app/src/main/java/com/uwcs446/socialsports/ui/matchrating/ViewPagerAdapter.kt
@@ -5,11 +5,11 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.RatingBar
 import android.widget.TextView
-import android.widget.Toast
 import androidx.recyclerview.widget.RecyclerView
 import com.uwcs446.socialsports.R
+import com.uwcs446.socialsports.domain.user.User
 
-class ViewPagerAdapter(private var userNames: List<String>) : RecyclerView.Adapter<ViewPagerAdapter.Pager2ViewHolder>() {
+class ViewPagerAdapter(private var userNames: List<User>) : RecyclerView.Adapter<ViewPagerAdapter.Pager2ViewHolder>() {
 
     private var userRatingList = MutableList(userNames.size) { 0F }
 
@@ -22,7 +22,6 @@ class ViewPagerAdapter(private var userNames: List<String>) : RecyclerView.Adapt
             userRatingBar.setOnRatingBarChangeListener { ratingBar: RatingBar, fl: Float, b: Boolean ->
                 val position = adapterPosition
                 userRatingList[position] = fl
-                Toast.makeText(itemView.context, "you clicked on item #${position + 1}", Toast.LENGTH_SHORT).show()
             }
         }
     }
@@ -35,10 +34,14 @@ class ViewPagerAdapter(private var userNames: List<String>) : RecyclerView.Adapt
     }
 
     override fun onBindViewHolder(holder: ViewPagerAdapter.Pager2ViewHolder, position: Int) {
-        holder.userNameText.text = userNames[position]
+        holder.userNameText.text = userNames[position].name
     }
 
     override fun getItemCount(): Int {
         return userNames.size
+    }
+
+    fun getPlayerRatingList(): MutableList<Float> {
+        return userRatingList
     }
 }


### PR DESCRIPTION
Past games was showing the join/leave button so this allows users to leave games after the game is done. I found this bug while demoing a bug in another PR. https://github.com/SPahooja/SocialSports/pull/79#discussion_r684672947

We basically just set the visibility to GONE for past games.

I also ran the linter and fixed linting in another file.

Before:

https://user-images.githubusercontent.com/6414135/128619483-d3107f22-e6ed-4a92-8de3-a935483f7e53.mp4

After:

https://user-images.githubusercontent.com/6414135/128619499-ec5dbf47-0254-48e3-ad99-9ba2e6b9e717.mp4

